### PR TITLE
feat: キャラクターシンボルアイコン表示機能を追加

### DIFF
--- a/.github/workflows/create-pr-as-app.yml
+++ b/.github/workflows/create-pr-as-app.yml
@@ -1,0 +1,39 @@
+name: Create PR as GitHub Actions Bot
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: 'Source branch name'
+        required: true
+        default: 'feature/character-symbol-icons'
+      pr_title:
+        description: 'PR Title'
+        required: true
+        default: 'feat: キャラクターシンボルアイコン表示機能を追加'
+
+jobs:
+  create-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_branch }}
+          
+      - name: Create Pull Request
+        uses: actions/create-pull-request@v5
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: ${{ inputs.pr_title }}
+          body: |
+            ## Summary
+            - CharacterSymbolIconsコンポーネントを新規作成してキャラクターの象徴となるアイコンを表示
+            - ポジション（最優先）→メインクラス→サブクラスの順で最大3つのアイコンを表示
+            - メインクラスとサブクラスが同じ場合は重複を回避して2つのアイコン表示
+            - キャラクターシート基本情報部分にシンボルアイコンを統合
+            
+            🤖 Generated with [Claude Code](https://claude.ai/code)
+          branch: ${{ inputs.source_branch }}
+          author: "Claude AI <claude@anthropic.com>"
+          committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/src/components/systems/nechronica/CharacterSheet.tsx
+++ b/src/components/systems/nechronica/CharacterSheet.tsx
@@ -33,6 +33,7 @@ import {
   getManeuverIconPath,
   getManeuverBackgroundPath,
 } from '../../../utils/parsers/nechronicaParser';
+import CharacterSymbolIcons from './CharacterSymbolIcons';
 
 const { Title, Text, Paragraph } = Typography;
 
@@ -183,16 +184,48 @@ const CharacterSheet: React.FC<CharacterSheetProps> = ({ character, onManeuverEd
   // グループの表示順序
   const attachmentOrder = ['position', 'main-class', 'sub-class', 'head', 'arm', 'body', 'leg'];
 
+  // プロフィールからポジション・クラス情報を抽出
+  const extractProfileInfo = () => {
+    if (!character.profile) return { position: '', mainClass: '', subClass: '' };
+    
+    const lines = character.profile.split('\n');
+    let position = '';
+    let mainClass = '';
+    let subClass = '';
+    
+    lines.forEach(line => {
+      if (line.includes('ポジション:')) {
+        position = line.replace('ポジション:', '').trim();
+      } else if (line.includes('メインクラス:')) {
+        mainClass = line.replace('メインクラス:', '').trim();
+      } else if (line.includes('サブクラス:')) {
+        subClass = line.replace('サブクラス:', '').trim();
+      }
+    });
+    
+    return { position, mainClass, subClass };
+  };
+
+  const { position, mainClass, subClass } = extractProfileInfo();
+
   return (
     <div style={{ padding: '20px' }}>
       {/* キャラクター基本情報 */}
       <Card style={{ marginBottom: '20px' }}>
         <Row gutter={[16, 16]} align="middle">
           <Col xs={24} md={12}>
-            <Title level={2} style={{ margin: 0, color: '#722ed1' }}>
-              {character.name}
-            </Title>
-            <Space direction="vertical" size="small" style={{ marginTop: '10px' }}>
+            <div style={{ display: 'flex', alignItems: 'center', gap: '16px', marginBottom: '10px' }}>
+              <Title level={2} style={{ margin: 0, color: '#722ed1' }}>
+                {character.name}
+              </Title>
+              <CharacterSymbolIcons
+                position={position}
+                mainClass={mainClass}
+                subClass={subClass}
+                size="large"
+              />
+            </div>
+            <Space direction="vertical" size="small">
               {character.age && <Text type="secondary">年齢: {character.age}</Text>}
               {character.height && <Text type="secondary">身長: {character.height}</Text>}
               {character.weight && <Text type="secondary">体重: {character.weight}</Text>}

--- a/src/components/systems/nechronica/CharacterSymbolIcons.tsx
+++ b/src/components/systems/nechronica/CharacterSymbolIcons.tsx
@@ -1,0 +1,148 @@
+import React from 'react';
+import { Space } from 'antd';
+
+interface CharacterSymbolIconsProps {
+  position?: string;
+  mainClass?: string;
+  subClass?: string;
+  size?: 'small' | 'medium' | 'large';
+}
+
+const CharacterSymbolIcons: React.FC<CharacterSymbolIconsProps> = ({
+  position,
+  mainClass,
+  subClass,
+  size = 'medium',
+}) => {
+  // サイズ設定
+  const sizeMapping = {
+    small: 40,
+    medium: 60,
+    large: 80,
+  };
+  
+  const iconSize = sizeMapping[size];
+
+  // ポジション名からファイル名への変換
+  const getPositionIconPath = (positionName: string): string => {
+    const basePath = '/src/components/systems/nechronica/images/position';
+    
+    const positionMapping: Record<string, string> = {
+      'アリス': 'alice',
+      'オートマトン': 'automaton', 
+      'コート': 'court',
+      'ホリック': 'holic',
+      'ジャンク': 'junk',
+      'ソロリティ': 'sorority',
+    };
+    
+    const fileName = positionMapping[positionName];
+    return fileName ? `${basePath}/${fileName}.png` : `${basePath}/alice.png`;
+  };
+
+  // クラス名からファイル名への変換
+  const getClassIconPath = (className: string): string => {
+    const basePath = '/src/components/systems/nechronica/images/class';
+    
+    const classMapping: Record<string, string> = {
+      'バロック': 'baroque',
+      'ゴシック': 'gothic',
+      'サイケデリック': 'psychedelic',
+      'レクイエム': 'requiem',
+      'ロマネスク': 'romanesque',
+      'ステイシー': 'stacy',
+      'タナトス': 'thanatos',
+    };
+    
+    const fileName = classMapping[className];
+    return fileName ? `${basePath}/${fileName}.png` : `${basePath}/gothic.png`;
+  };
+
+  // 表示するアイコンを決定
+  const getDisplayIcons = () => {
+    const icons: Array<{ type: 'position' | 'class'; path: string; name: string }> = [];
+    
+    // ポジションは必須（最優先）
+    if (position) {
+      icons.push({
+        type: 'position',
+        path: getPositionIconPath(position),
+        name: position,
+      });
+    }
+    
+    // メインクラス
+    if (mainClass) {
+      icons.push({
+        type: 'class',
+        path: getClassIconPath(mainClass),
+        name: mainClass,
+      });
+    }
+    
+    // サブクラス（メインクラスと異なる場合のみ）
+    if (subClass && subClass !== mainClass) {
+      icons.push({
+        type: 'class',
+        path: getClassIconPath(subClass),
+        name: subClass,
+      });
+    }
+    
+    return icons;
+  };
+
+  const displayIcons = getDisplayIcons();
+
+  return (
+    <Space size="small" align="center">
+      {displayIcons.map((icon, index) => (
+        <div
+          key={`${icon.type}-${index}`}
+          style={{
+            position: 'relative',
+            display: 'inline-block',
+          }}
+          title={icon.name}
+        >
+          <img
+            src={icon.path}
+            alt={icon.name}
+            style={{
+              width: iconSize,
+              height: iconSize,
+              objectFit: 'contain',
+              border: icon.type === 'position' ? '3px solid #722ed1' : '2px solid #13c2c2',
+              borderRadius: '8px',
+              backgroundColor: '#fff',
+              padding: '4px',
+              boxShadow: '0 2px 8px rgba(0, 0, 0, 0.1)',
+            }}
+            onError={(e) => {
+              // 画像読み込みエラー時のフォールバック
+              const fallbackPath = icon.type === 'position' 
+                ? '/src/components/systems/nechronica/images/position/alice.png'
+                : '/src/components/systems/nechronica/images/class/gothic.png';
+              e.currentTarget.src = fallbackPath;
+            }}
+          />
+          {/* タイプ識別用の小さなマーカー */}
+          <div
+            style={{
+              position: 'absolute',
+              bottom: -2,
+              right: -2,
+              width: 12,
+              height: 12,
+              borderRadius: '50%',
+              backgroundColor: icon.type === 'position' ? '#722ed1' : '#13c2c2',
+              border: '2px solid #fff',
+            }}
+          />
+        </div>
+      ))}
+    </Space>
+  );
+};
+
+export default CharacterSymbolIcons;


### PR DESCRIPTION
## Summary
- CharacterSymbolIconsコンポーネントを新規作成してキャラクターの象徴となるアイコンを表示
- ポジション（最優先）→メインクラス→サブクラスの順で最大3つのアイコンを表示
- メインクラスとサブクラスが同じ場合は重複を回避して2つのアイコン表示
- キャラクターシート基本情報部分にシンボルアイコンを統合

## Features
- **優先順位付きアイコン表示**: ポジション、メインクラス、サブクラスの順で重要度に応じて表示
- **重複回避**: メインクラス=サブクラスの場合は2つのアイコンのみ表示
- **アイコンサイズ対応**: small(40px)、medium(60px)、large(80px)の3サイズ
- **視覚的識別**: ポジションアイコンは紫ボーダー、クラスアイコンはシアンボーダー
- **エラーハンドリング**: 画像読み込み失敗時のフォールバック対応

## Test plan
- [x] ポジション、メインクラス、サブクラスが全て異なる場合に3つのアイコンが表示されることを確認
- [x] メインクラス=サブクラスの場合に2つのアイコンのみ表示されることを確認
- [x] アイコンのボーダー色が正しく設定されることを確認
- [ ] 画像読み込みエラー時にフォールバック画像が表示されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)