### PR TITLE
feat: マニューバの使用済み・損傷状態切り替え機能を追加

### DIFF
--- a/src/pages/systems/nechronica/NechronicaPage.tsx
+++ b/src/pages/systems/nechronica/NechronicaPage.tsx
@@ -98,6 +98,27 @@ const NechronicaPage: React.FC = () => {
     }
   };
 
+  const handleManeuverStatusChange = (
+    maneuverIndex: number,
+    field: 'damaged' | 'used',
+    value: boolean
+  ) => {
+    if (character) {
+      const updatedCharacter = {
+        ...character,
+        maneuvers: character.maneuvers.map((maneuver, index) =>
+          index === maneuverIndex ? { ...maneuver, [field]: value } : maneuver
+        ),
+      };
+      setCharacter(updatedCharacter);
+      
+      // 操作フィードバック
+      const action = value ? '設定' : '解除';
+      const statusName = field === 'damaged' ? '損傷' : '使用済み';
+      message.success(`${character.maneuvers[maneuverIndex].name}を${statusName}に${action}しました`);
+    }
+  };
+
   return (
     <Layout style={{ minHeight: '100vh' }}>
       {isAuthenticated ? (
@@ -119,7 +140,11 @@ const NechronicaPage: React.FC = () => {
                 新しいキャラクターを表示
               </Button>
             </div>
-            <CharacterSheet character={character} onManeuverEdit={handleManeuverEdit} />
+            <CharacterSheet 
+              character={character} 
+              onManeuverEdit={handleManeuverEdit}
+              onManeuverStatusChange={handleManeuverStatusChange}
+            />
           </div>
         ) : (
           // URL入力画面

--- a/src/types/systems/nechronica.ts
+++ b/src/types/systems/nechronica.ts
@@ -53,6 +53,8 @@ export interface NechronicaManeuver {
   description: string;
   attachment: 'position' | 'main-class' | 'sub-class' | 'head' | 'arm' | 'body' | 'leg';
   powerType: number; // 0: なし, 1: 通常, 2: 必殺技, 3: 行動値増加, 4: 補助, 5: 妨害, 6: 防御/生贄, 7: 移動
+  damaged?: boolean; // 損傷状態
+  used?: boolean; // 使用済み状態（1ターンあたりの制限など）
 }
 
 export interface MemoryFragment {


### PR DESCRIPTION
## Summary

- マニューバカードに使用済み（✓）と損傷（×）の状態を切り替えるボタンを追加
- 各状態に応じた視覚的フィードバック（色彩変更、透明度、フィルタ効果）を実装  
- 部位一覧表示に使用済み状態の集計を追加
- TypeScript型定義を拡張してdamaged、usedフィールドをサポート

## Test plan

- [ ] マニューバの使用済み状態ボタンが正常に動作することを確認
- [ ] マニューバの損傷状態ボタンが正常に動作することを確認
- [ ] 状態変更時の視覚的フィードバックが適切に表示されることを確認
- [ ] 部位表示に使用済み・損傷の集計が正しく反映されることを確認
- [ ] 既存のマニューバ編集機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)